### PR TITLE
fix: use isInline prop instead of inline-link styles

### DIFF
--- a/src/register/RegistrationFields/HonorCodeField/HonorCode.jsx
+++ b/src/register/RegistrationFields/HonorCodeField/HonorCode.jsx
@@ -31,7 +31,7 @@ const HonorCode = (props) => {
             platformName: getConfig().SITE_NAME,
             tosAndHonorCode: (
               <Hyperlink
-                className="inline-link"
+                isInline
                 destination={getConfig().TOS_AND_HONOR_CODE || '#'}
                 target="_blank"
                 showLaunchIcon={false}
@@ -41,7 +41,7 @@ const HonorCode = (props) => {
             ),
             privacyPolicy: (
               <Hyperlink
-                className="inline-link"
+                isInline
                 destination={getConfig().PRIVACY_POLICY || '#'}
                 target="_blank"
                 showLaunchIcon={false}


### PR DESCRIPTION
### Description
This PR updates the usage of the <Hyperlink /> component in the Authn MFE to use the isInline prop instead of manually passing the "inline-link" class via className.

The isInline prop on the <Hyperlink /> component defaults to false, which causes it to internally apply the standalone-link class in addition to any class passed through className. As a result, both inline-link and standalone-link classes were being applied simultaneously.

This conflict led to styling issues that caused the link to sometimes not render properly or appear invisible, especially in places where visual styling depends heavily on the correct class being applied.

The fix is to use the dedicated isInline prop so only one of the classes is applied
