### PR TITLE
feat: add support for edly registration form overrides

### DIFF
--- a/src/common-components/PasswordField.jsx
+++ b/src/common-components/PasswordField.jsx
@@ -46,11 +46,14 @@ const PasswordField = (props) => {
 
     setShowTooltip(props.showRequirements && false);
     if (props.handleErrorChange) { // If rendering from register page
-      const fieldError = validatePasswordField(passwordValue, formatMessage);
+      const { fieldError, confirmPasswordError } = validatePasswordField(passwordValue, formatMessage, props.confirmPasswordValue);
       if (fieldError) {
         props.handleErrorChange('password', fieldError);
       } else if (!validationApiRateLimited) {
         dispatch(fetchRealtimeValidations({ password: passwordValue }));
+      }
+      if (confirmPasswordError) {
+        props.handleErrorChange('confirm_password', confirmPasswordError); 
       }
     }
   };
@@ -65,6 +68,7 @@ const PasswordField = (props) => {
     }
     if (props.handleErrorChange) {
       props.handleErrorChange('password', '');
+      props.handleErrorChange('confirm_password', '');
       dispatch(clearRegistrationBackendError('password'));
     }
     setTimeout(() => setShowTooltip(props.showRequirements && true), 150);
@@ -155,6 +159,7 @@ PasswordField.defaultProps = {
   showRequirements: true,
   showScreenReaderText: true,
   autoComplete: null,
+  confirmPasswordValue: null,
 };
 
 PasswordField.propTypes = {
@@ -170,6 +175,7 @@ PasswordField.propTypes = {
   value: PropTypes.string.isRequired,
   autoComplete: PropTypes.string,
   showScreenReaderText: PropTypes.bool,
+  confirmPasswordValue: PropTypes.string,
 };
 
 export default PasswordField;

--- a/src/common-components/PasswordField.jsx
+++ b/src/common-components/PasswordField.jsx
@@ -11,7 +11,7 @@ import {
 import PropTypes from 'prop-types';
 
 import messages from './messages';
-import { LETTER_REGEX, NUMBER_REGEX } from '../data/constants';
+import { LETTER_REGEX, NUMBER_REGEX, SYMBOL_REGEX } from '../data/constants';
 import { clearRegistrationBackendError, fetchRealtimeValidations } from '../register/data/actions';
 import { validatePasswordField } from '../register/data/utils';
 
@@ -46,14 +46,18 @@ const PasswordField = (props) => {
 
     setShowTooltip(props.showRequirements && false);
     if (props.handleErrorChange) { // If rendering from register page
-      const { fieldError, confirmPasswordError } = validatePasswordField(passwordValue, formatMessage, props.confirmPasswordValue);
+      const { fieldError, confirmPasswordError } = validatePasswordField(
+        passwordValue,
+        formatMessage,
+        props.confirmPasswordValue,
+      );
       if (fieldError) {
         props.handleErrorChange('password', fieldError);
       } else if (!validationApiRateLimited) {
         dispatch(fetchRealtimeValidations({ password: passwordValue }));
       }
       if (confirmPasswordError) {
-        props.handleErrorChange('confirm_password', confirmPasswordError); 
+        props.handleErrorChange('confirm_password', confirmPasswordError);
       }
     }
   };
@@ -112,6 +116,10 @@ const PasswordField = (props) => {
       <span id="number-check" className="d-flex align-items-center">
         {NUMBER_REGEX.test(props.value) ? <Icon className="text-success mr-1" src={Check} /> : <Icon className="mr-1 text-light-700" src={Remove} />}
         {formatMessage(messages['one.number'])}
+      </span>
+      <span id="symbol-check" className="d-flex align-items-center">
+        {SYMBOL_REGEX.test(props.value) ? <Icon className="text-success mr-1" src={Check} /> : <Icon className="mr-1 text-light-700" src={Remove} />}
+        {formatMessage(messages['one.symbol'])}
       </span>
       <span id="characters-check" className="d-flex align-items-center">
         {props.value.length >= 8 ? <Icon className="text-success mr-1" src={Check} /> : <Icon className="mr-1 text-light-700" src={Remove} />}

--- a/src/common-components/messages.jsx
+++ b/src/common-components/messages.jsx
@@ -66,6 +66,11 @@ const messages = defineMessages({
     defaultMessage: '1 number',
     description: 'password requirement to have 1 number',
   },
+  'one.symbol': {
+    id: 'one.symbol',
+    defaultMessage: '1 symbol',
+    description: 'Password requirement for at least one symbol',
+  },
   'eight.characters': {
     id: 'eight.characters',
     defaultMessage: '8 characters',

--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -28,6 +28,7 @@ export const EMBEDDED = 'embedded';
 
 export const LETTER_REGEX = /[a-zA-Z]/;
 export const NUMBER_REGEX = /\d/;
+export const SYMBOL_REGEX = /[!@#$%^&*]/;
 export const VALID_EMAIL_REGEX = '(^[-!#$%&\'*+/=?^_`{}|~0-9A-Z]+(\\.[-!#$%&\'*+/=?^_`{}|~0-9A-Z]+)*'
                                  + '|^"([\\001-\\010\\013\\014\\016-\\037!#-\\[\\]-\\177]|\\\\[\\001-\\011\\013\\014\\016-\\177])*"'
                                  + ')@((?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\\.)+)(?:[A-Z0-9-]{2,63})'

--- a/src/field-renderer/FieldRenderer.jsx
+++ b/src/field-renderer/FieldRenderer.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Form, Icon } from '@openedx/paragon';
 import { ExpandMore } from '@openedx/paragon/icons';
 import PropTypes from 'prop-types';
+import PasswordField from '../common-components/PasswordField';
 
 const FormFieldRenderer = (props) => {
   let formField = null;
@@ -118,6 +119,21 @@ const FormFieldRenderer = (props) => {
             </Form.Control.Feedback>
           )}
         </Form.Group>
+      );
+      break;
+    }
+    case 'password': {
+      formField = (
+        <PasswordField
+          name={fieldData.name}
+          value={value}
+          errorMessage={errorMessage}
+          floatingLabel={fieldData.label}
+          handleChange={(e) => onChangeHandler(e)}
+          handleBlur={handleOnBlur}
+          showRequirements={false}
+          showScreenReaderText={false}
+        />
       );
       break;
     }

--- a/src/field-renderer/FieldRenderer.jsx
+++ b/src/field-renderer/FieldRenderer.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Form, Icon } from '@openedx/paragon';
 import { ExpandMore } from '@openedx/paragon/icons';
 import PropTypes from 'prop-types';
+
 import PasswordField from '../common-components/PasswordField';
 
 const FormFieldRenderer = (props) => {

--- a/src/register/RegistrationPage.jsx
+++ b/src/register/RegistrationPage.jsx
@@ -344,6 +344,7 @@ const RegistrationPage = (props) => {
                 <PasswordField
                   name="password"
                   value={formFields.password}
+                  confirmPasswordValue={configurableFormFields?.confirm_password}
                   handleChange={handleOnChange}
                   handleErrorChange={handleErrorChange}
                   errorMessage={errors.password}
@@ -352,6 +353,7 @@ const RegistrationPage = (props) => {
               )}
               <ConfigurableRegistrationForm
                 email={formFields.email}
+                password={formFields.password}
                 fieldErrors={errors}
                 formFields={configurableFormFields}
                 setFieldErrors={registrationEmbedded ? setTemporaryErrors : setErrors}

--- a/src/register/components/ConfigurableRegistrationForm.jsx
+++ b/src/register/components/ConfigurableRegistrationForm.jsx
@@ -25,6 +25,7 @@ const ConfigurableRegistrationForm = (props) => {
   const { formatMessage } = useIntl();
   const {
     email,
+    password,
     fieldDescriptions,
     fieldErrors,
     formFields,
@@ -100,6 +101,8 @@ const ConfigurableRegistrationForm = (props) => {
       error = fieldDescriptions[name].error_message;
     } else if (name === 'confirm_email' && value !== email) {
       error = formatMessage(messages['email.do.not.match']);
+    } else if (name === 'confirm_password' && value !== password) {
+      error = formatMessage(messages['password.do.not.match']);
     }
     setFieldErrors(prevErrors => ({ ...prevErrors, [name]: error }));
   };
@@ -216,6 +219,7 @@ const ConfigurableRegistrationForm = (props) => {
 
 ConfigurableRegistrationForm.propTypes = {
   email: PropTypes.string.isRequired,
+  password: PropTypes.string.isRequired,
   fieldDescriptions: PropTypes.shape({}),
   fieldErrors: PropTypes.shape({
     country: PropTypes.string,

--- a/src/register/data/utils.js
+++ b/src/register/data/utils.js
@@ -12,12 +12,16 @@ import validateUsername from '../RegistrationFields/UsernameField/validator';
  * @param formatMessage
  * @returns {string}
  */
-export const validatePasswordField = (value, formatMessage) => {
+export const validatePasswordField = (value, formatMessage, confirmPasswordValue) => {
   let fieldError = '';
+  let confirmPasswordError = '';
   if (!value || !LETTER_REGEX.test(value) || !NUMBER_REGEX.test(value) || value.length < 8) {
     fieldError = formatMessage(messages['password.validation.message']);
   }
-  return fieldError;
+  if (confirmPasswordValue && value !== confirmPasswordValue) {
+    confirmPasswordError = formatMessage(messages['password.do.not.match']);
+  }
+  return { fieldError, confirmPasswordError };
 };
 
 /**
@@ -74,7 +78,15 @@ export const isFormValid = (
       break;
     case 'password':
       if (!fieldErrors.password) {
-        fieldErrors.password = validatePasswordField(payload.password, formatMessage);
+        const { fieldError, confirmPasswordError } = validatePasswordField(payload.password, formatMessage, configurableFormFields?.confirm_password);
+        if (fieldError) {
+          fieldErrors.password = fieldError;
+          isValid = false;
+        }
+        if (confirmPasswordError) {
+          fieldErrors.confirm_password = confirmPasswordError;
+          isValid = false;
+        }
       }
       if (fieldErrors.password) { isValid = false; }
       break;

--- a/src/register/data/utils.js
+++ b/src/register/data/utils.js
@@ -1,6 +1,6 @@
 import { snakeCaseObject } from '@edx/frontend-platform';
 
-import { LETTER_REGEX, NUMBER_REGEX } from '../../data/constants';
+import { LETTER_REGEX, NUMBER_REGEX, SYMBOL_REGEX } from '../../data/constants';
 import messages from '../messages';
 import validateEmail from '../RegistrationFields/EmailField/validator';
 import validateName from '../RegistrationFields/NameField/validator';
@@ -15,7 +15,13 @@ import validateUsername from '../RegistrationFields/UsernameField/validator';
 export const validatePasswordField = (value, formatMessage, confirmPasswordValue) => {
   let fieldError = '';
   let confirmPasswordError = '';
-  if (!value || !LETTER_REGEX.test(value) || !NUMBER_REGEX.test(value) || value.length < 8) {
+  if (
+    !value
+    || !LETTER_REGEX.test(value)
+    || !NUMBER_REGEX.test(value)
+    || value.length < 8
+    || !SYMBOL_REGEX.test(value)
+  ) {
     fieldError = formatMessage(messages['password.validation.message']);
   }
   if (confirmPasswordValue && value !== confirmPasswordValue) {
@@ -78,7 +84,11 @@ export const isFormValid = (
       break;
     case 'password':
       if (!fieldErrors.password) {
-        const { fieldError, confirmPasswordError } = validatePasswordField(payload.password, formatMessage, configurableFormFields?.confirm_password);
+        const { fieldError, confirmPasswordError } = validatePasswordField(
+          payload.password,
+          formatMessage,
+          configurableFormFields?.confirm_password,
+        );
         if (fieldError) {
           fieldErrors.password = fieldError;
           isValid = false;

--- a/src/register/messages.jsx
+++ b/src/register/messages.jsx
@@ -9,22 +9,22 @@ const messages = defineMessages({
   // Field labels
   'registration.fullname.label': {
     id: 'registration.fullname.label',
-    defaultMessage: 'Full name',
+    defaultMessage: 'Full name*',
     description: 'Label that appears above fullname field',
   },
   'registration.email.label': {
     id: 'registration.email.label',
-    defaultMessage: 'Email',
+    defaultMessage: 'Email*',
     description: 'Label that appears above email field on register page',
   },
   'registration.username.label': {
     id: 'registration.username.label',
-    defaultMessage: 'Public username',
+    defaultMessage: 'Public username*',
     description: 'Label that appears above username field',
   },
   'registration.password.label': {
     id: 'registration.password.label',
-    defaultMessage: 'Password',
+    defaultMessage: 'Password*',
     description: 'Label that appears above password field',
   },
   'registration.country.label': {

--- a/src/register/messages.jsx
+++ b/src/register/messages.jsx
@@ -131,6 +131,11 @@ const messages = defineMessages({
     defaultMessage: 'Password criteria has not been met',
     description: 'Error message for empty or invalid password',
   },
+  'password.do.not.match': {
+    id: 'password.do.not.match',
+    defaultMessage: 'The passwords do not match.',
+    description: 'Password not match to confirm password',
+  },
   'username.format.validation.message': {
     id: 'username.format.validation.message',
     defaultMessage: 'Usernames can only contain letters (A-Z, a-z), numerals (0-9), underscores (_), and hyphens (-). Usernames cannot contain spaces',


### PR DESCRIPTION
### Description
This PR does the following
- Add support for Reset password field
- Add asterisk(*) infront of required field labels in registraiton form
- Enforce symbol validation for these symbols [ !@#$%^&*]

### Ticket
https://projects.arbisoft.com/project/edly-product/us/7294

### Linked PR
[edly-features-app](https://github.com/edly-io/edly-features-app/pull/16)