### PR TITLE
feat(auth): implement two factor authentication

### DIFF
--- a/src/MainApp.jsx
+++ b/src/MainApp.jsx
@@ -31,10 +31,8 @@ import './index.scss';
 
 registerIcons();
 
-const store = configureStore();
-
 const MainApp = () => (
-  <AppProvider store={store}>
+  <AppProvider store={configureStore()}>
     <Helmet>
       <link rel="shortcut icon" href={getConfig().FAVICON_URL} type="image/x-icon" />
     </Helmet>

--- a/src/MainApp.jsx
+++ b/src/MainApp.jsx
@@ -31,8 +31,10 @@ import './index.scss';
 
 registerIcons();
 
+const store = configureStore();
+
 const MainApp = () => (
-  <AppProvider store={configureStore()}>
+  <AppProvider store={store}>
     <Helmet>
       <link rel="shortcut icon" href={getConfig().FAVICON_URL} type="image/x-icon" />
     </Helmet>

--- a/src/data/configureStore.js
+++ b/src/data/configureStore.js
@@ -8,20 +8,20 @@ import thunkMiddleware from 'redux-thunk';
 import createRootReducer from './reducers';
 import rootSaga from './sagas';
 
-const sagaMiddleware = createSagaMiddleware();
+export default function configureStore(initialState = {}) {
+  const sagaMiddleware = createSagaMiddleware();
 
-function composeMiddleware() {
-  if (getConfig().ENVIRONMENT === 'development') {
-    const loggerMiddleware = createLogger({
-      collapsed: true,
-    });
-    return composeWithDevTools(applyMiddleware(thunkMiddleware, sagaMiddleware, loggerMiddleware));
+  function composeMiddleware() {
+    if (getConfig().ENVIRONMENT === 'development') {
+      const loggerMiddleware = createLogger({
+        collapsed: true,
+      });
+      return composeWithDevTools(applyMiddleware(thunkMiddleware, sagaMiddleware, loggerMiddleware));
+    }
+
+    return compose(applyMiddleware(thunkMiddleware, sagaMiddleware));
   }
 
-  return compose(applyMiddleware(thunkMiddleware, sagaMiddleware));
-}
-
-export default function configureStore(initialState = {}) {
   const store = createStore(
     createRootReducer(),
     initialState,

--- a/src/login/LoginPage.jsx
+++ b/src/login/LoginPage.jsx
@@ -1,5 +1,5 @@
 import {
-  useCallback, useEffect, useMemo, useState,
+  useCallback, useEffect, useMemo, useRef, useState,
 } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -37,6 +37,7 @@ import { backupLoginFormBegin, dismissPasswordResetBanner, loginRequest } from '
 import { INVALID_FORM, TPA_AUTHENTICATION_FAILURE } from './data/constants';
 import LoginFailureMessage from './LoginFailure';
 import messages from './messages';
+import TwoFactorAuth from './TwoFactorAuth';
 
 const LoginPage = ({
   institutionLogin,
@@ -55,6 +56,7 @@ const LoginPage = ({
     submitState,
     thirdPartyAuthContext,
     thirdPartyAuthApiStatus,
+    twoFactorAuthRequired,
   } = useSelector((state) => ({
     backedUpFormData: state.login.loginFormData,
     loginErrorCode: state.login.loginErrorCode,
@@ -65,6 +67,7 @@ const LoginPage = ({
     submitState: state.login.submitState,
     thirdPartyAuthContext: thirdPartyAuthContextSelector(state),
     thirdPartyAuthApiStatus: state.commonComponents.thirdPartyAuthApiStatus,
+    twoFactorAuthRequired: state.login.twoFactorAuthRequired,
   }));
   const {
     providers,
@@ -86,6 +89,7 @@ const LoginPage = ({
   });
   const [errors, setErrors] = useState({ ...backedUpFormData.errors });
   const tpaHint = getTpaHint();
+  const isSubmittingRef = useRef(false);
 
   useEffect(() => {
     sendPageEvent('login_and_registration', 'login');
@@ -112,6 +116,7 @@ const LoginPage = ({
 
   useEffect(() => {
     if (loginErrorCode) {
+      isSubmittingRef.current = false;
       setErrorCode(prevState => ({
         type: loginErrorCode,
         count: prevState.count + 1,
@@ -119,6 +124,12 @@ const LoginPage = ({
       }));
     }
   }, [loginErrorCode, loginErrorContext]);
+
+  useEffect(() => {
+    if (twoFactorAuthRequired) {
+      isSubmittingRef.current = false;
+    }
+  }, [twoFactorAuthRequired]);
 
   useEffect(() => {
     if (thirdPartyErrorMessage) {
@@ -153,6 +164,13 @@ const LoginPage = ({
 
   const handleSubmit = (event) => {
     event.preventDefault();
+    if (twoFactorAuthRequired) {
+      return;
+    }
+    if (isSubmittingRef.current) {
+      return;
+    }
+
     if (showResetPasswordSuccessBanner) {
       dispatch(dismissPasswordResetBanner());
     }
@@ -169,7 +187,7 @@ const LoginPage = ({
       return;
     }
 
-    // add query params to the payload
+    isSubmittingRef.current = true;
     const payload = {
       email_or_username: formData.emailOrUsername,
       password: formData.password,
@@ -228,6 +246,24 @@ const LoginPage = ({
       />
     );
   }
+
+  if (twoFactorAuthRequired) {
+    return (
+      <>
+        <Helmet>
+          <title>{formatMessage(messages['2fa.page.title'])}</title>
+        </Helmet>
+        <RedirectLogistration
+          success={loginResult.success}
+          redirectUrl={loginResult.redirectUrl}
+          finishAuthUrl={finishAuthUrl}
+        />
+        <h4 className="mt-3">{formatMessage(messages['2fa.page.title'])}</h4>
+        <TwoFactorAuth />
+      </>
+    );
+  }
+
   return (
     <>
       <Helmet>

--- a/src/login/TwoFactorAuth.jsx
+++ b/src/login/TwoFactorAuth.jsx
@@ -1,0 +1,183 @@
+import { useEffect, useRef, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { useIntl } from '@edx/frontend-platform/i18n';
+import {
+  Alert, Form, StatefulButton,
+} from '@openedx/paragon';
+import { CheckCircle, Error } from '@openedx/paragon/icons';
+
+import { PENDING_STATE } from '../data/constants';
+import { twoFactorAuthVerifyRequest, twoFactorAuthResendRequest } from './data/actions';
+import messages from './messages';
+import { windowScrollTo } from '../data/utils';
+
+const TwoFactorAuth = () => {
+  const dispatch = useDispatch();
+  const { formatMessage } = useIntl();
+
+  const {
+    maskedEmail,
+    submitState,
+    errorCode,
+    resendState,
+    resendSuccess,
+    loginResult,
+  } = useSelector(state => ({
+    maskedEmail: state.login.twoFactorAuthMaskedEmail,
+    submitState: state.login.twoFactorAuthSubmitState,
+    errorCode: state.login.twoFactorAuthErrorCode,
+    resendState: state.login.twoFactorAuthResendState,
+    resendSuccess: state.login.twoFactorAuthResendSuccess,
+    loginResult: state.login.loginResult,
+  }));
+
+  const [otp, setOtp] = useState('');
+  const [otpError, setOtpError] = useState('');
+  const isSubmittingRef = useRef(false);
+  const isResendingRef = useRef(false);
+
+  useEffect(() => {
+    if (errorCode) {
+      isSubmittingRef.current = false;
+      windowScrollTo({ left: 0, top: 0, behavior: 'smooth' });
+    }
+  }, [errorCode]);
+
+  useEffect(() => {
+    if (submitState !== PENDING_STATE) {
+      isSubmittingRef.current = false;
+    }
+  }, [submitState]);
+
+  useEffect(() => {
+    if (resendState !== PENDING_STATE) {
+      isResendingRef.current = false;
+    }
+  }, [resendState]);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (isSubmittingRef.current) {
+      return;
+    }
+    if (!otp.trim()) {
+      setOtpError(formatMessage(messages['2fa.otp.validation.empty']));
+      return;
+    }
+    if (!/^\d{6}$/.test(otp.trim())) {
+      setOtpError(formatMessage(messages['2fa.otp.validation.format']));
+      return;
+    }
+    setOtpError('');
+    isSubmittingRef.current = true;
+    dispatch(twoFactorAuthVerifyRequest(otp.trim()));
+  };
+
+  const handleResend = () => {
+    if (isResendingRef.current || resendState === PENDING_STATE) {
+      return;
+    }
+    isResendingRef.current = true;
+    dispatch(twoFactorAuthResendRequest());
+  };
+
+  const getErrorMessage = () => {
+    switch (errorCode) {
+      case '2fa-invalid-otp':
+        return formatMessage(messages['2fa.error.invalid.otp']);
+      case '2fa-session-expired':
+        return formatMessage(messages['2fa.error.session.expired']);
+      case '2fa-resend-rate-limited':
+        return formatMessage(messages['2fa.error.resend.rate.limited']);
+      case 'forbidden-request':
+        return formatMessage(messages['2fa.error.too.many.attempts']);
+      default:
+        return formatMessage(messages['2fa.error.internal']);
+    }
+  };
+
+  if (loginResult && loginResult.success) {
+    return null;
+  }
+
+  return (
+    <div className="mw-xs mt-3 mb-2">
+      {errorCode && (
+        <Alert id="2fa-failure-alert" className="mb-5" variant="danger" icon={Error}>
+          <Alert.Heading>{formatMessage(messages['2fa.error.heading'])}</Alert.Heading>
+          <p>{getErrorMessage()}</p>
+        </Alert>
+      )}
+
+      {resendSuccess && !errorCode && (
+        <Alert id="2fa-resend-success-alert" className="mb-5" variant="success" icon={CheckCircle}>
+          <p>{formatMessage(messages['2fa.resend.success'])}</p>
+        </Alert>
+      )}
+
+      <p className="mb-4 small">
+        {maskedEmail
+          ? formatMessage(messages['2fa.description.with.email'], { maskedEmail })
+          : formatMessage(messages['2fa.description'])}
+      </p>
+
+      <Form id="2fa-form" name="2fa-form">
+        <Form.Group controlId="otp" isInvalid={!!otpError}>
+          <Form.Control
+            as="input"
+            type="text"
+            inputMode="numeric"
+            autoComplete="one-time-code"
+            name="otp"
+            value={otp}
+            onChange={e => setOtp(e.target.value)}
+            floatingLabel={formatMessage(messages['2fa.otp.label'])}
+            maxLength={6}
+          />
+          {otpError && (
+            <Form.Control.Feedback type="invalid">
+              {otpError}
+            </Form.Control.Feedback>
+          )}
+        </Form.Group>
+
+        <StatefulButton
+          name="verify-otp"
+          id="verify-otp"
+          type="submit"
+          variant="brand"
+          className="login-button-width"
+          state={submitState}
+          labels={{
+            default: formatMessage(messages['2fa.verify.button']),
+            pending: '',
+          }}
+          disabledStates={[PENDING_STATE]}
+          onClick={handleSubmit}
+          onMouseDown={e => e.preventDefault()}
+        />
+      </Form>
+
+      <div className="mt-3">
+        <StatefulButton
+          name="resend-otp"
+          id="resend-otp"
+          type="button"
+          variant="tertiary"
+          className="font-weight-500 text-body"
+          state={resendState}
+          labels={{
+            default: formatMessage(messages['2fa.resend.button']),
+            pending: formatMessage(messages['2fa.resend.button.pending']),
+          }}
+          disabledStates={[PENDING_STATE]}
+          onClick={handleResend}
+          onMouseDown={e => e.preventDefault()}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default TwoFactorAuth;

--- a/src/login/data/actions.js
+++ b/src/login/data/actions.js
@@ -37,3 +37,41 @@ export const loginRequestFailure = (loginError) => ({
 export const dismissPasswordResetBanner = () => ({
   type: DISMISS_PASSWORD_RESET_BANNER,
 });
+
+// Two Factor Auth
+export const TWO_FACTOR_AUTH_REQUIRED_ACTION = 'TWO_FACTOR_AUTH_REQUIRED';
+export const TWO_FACTOR_AUTH_VERIFY = new AsyncActionType('LOGIN', 'TWO_FACTOR_AUTH_VERIFY');
+export const TWO_FACTOR_AUTH_RESEND = new AsyncActionType('LOGIN', 'TWO_FACTOR_AUTH_RESEND');
+
+export const twoFactorAuthRequired = (maskedEmail) => ({
+  type: TWO_FACTOR_AUTH_REQUIRED_ACTION,
+  payload: { maskedEmail },
+});
+
+export const twoFactorAuthVerifyRequest = (otp) => ({
+  type: TWO_FACTOR_AUTH_VERIFY.BASE,
+  payload: { otp },
+});
+
+export const twoFactorAuthVerifyBegin = () => ({ type: TWO_FACTOR_AUTH_VERIFY.BEGIN });
+
+export const twoFactorAuthVerifySuccess = (redirectUrl) => ({
+  type: TWO_FACTOR_AUTH_VERIFY.SUCCESS,
+  payload: { redirectUrl },
+});
+
+export const twoFactorAuthVerifyFailure = (errorCode) => ({
+  type: TWO_FACTOR_AUTH_VERIFY.FAILURE,
+  payload: { errorCode },
+});
+
+export const twoFactorAuthResendRequest = () => ({ type: TWO_FACTOR_AUTH_RESEND.BASE });
+
+export const twoFactorAuthResendBegin = () => ({ type: TWO_FACTOR_AUTH_RESEND.BEGIN });
+
+export const twoFactorAuthResendSuccess = () => ({ type: TWO_FACTOR_AUTH_RESEND.SUCCESS });
+
+export const twoFactorAuthResendFailure = (errorCode) => ({
+  type: TWO_FACTOR_AUTH_RESEND.FAILURE,
+  payload: { errorCode },
+});

--- a/src/login/data/constants.js
+++ b/src/login/data/constants.js
@@ -1,4 +1,8 @@
 // Login Error Codes
+export const TWO_FACTOR_AUTH_REQUIRED = '2fa-required';
+export const TWO_FACTOR_AUTH_INVALID_OTP = '2fa-invalid-otp';
+export const TWO_FACTOR_AUTH_SESSION_EXPIRED = '2fa-session-expired';
+export const TWO_FACTOR_AUTH_RESEND_RATE_LIMITED = '2fa-resend-rate-limited';
 export const INACTIVE_USER = 'inactive-user';
 export const INTERNAL_SERVER_ERROR = 'internal-server-error';
 export const INVALID_FORM = 'invalid-form';

--- a/src/login/data/reducers.js
+++ b/src/login/data/reducers.js
@@ -2,6 +2,9 @@ import {
   BACKUP_LOGIN_DATA,
   DISMISS_PASSWORD_RESET_BANNER,
   LOGIN_REQUEST,
+  TWO_FACTOR_AUTH_REQUIRED_ACTION,
+  TWO_FACTOR_AUTH_VERIFY,
+  TWO_FACTOR_AUTH_RESEND,
 } from './actions';
 import { DEFAULT_STATE, PENDING_STATE } from '../../data/constants';
 import { RESET_PASSWORD } from '../../reset-password';
@@ -21,6 +24,12 @@ export const defaultState = {
   shouldBackupState: false,
   showResetPasswordSuccessBanner: false,
   submitState: DEFAULT_STATE,
+  twoFactorAuthRequired: false,
+  twoFactorAuthMaskedEmail: '',
+  twoFactorAuthSubmitState: DEFAULT_STATE,
+  twoFactorAuthErrorCode: '',
+  twoFactorAuthResendState: DEFAULT_STATE,
+  twoFactorAuthResendSuccess: false,
 };
 
 const reducer = (state = defaultState, action = {}) => {
@@ -55,6 +64,53 @@ const reducer = (state = defaultState, action = {}) => {
         submitState: DEFAULT_STATE,
       };
     }
+    case TWO_FACTOR_AUTH_REQUIRED_ACTION:
+      return {
+        ...state,
+        submitState: DEFAULT_STATE,
+        twoFactorAuthRequired: true,
+        twoFactorAuthMaskedEmail: action.payload.maskedEmail || '',
+        twoFactorAuthErrorCode: '',
+        twoFactorAuthResendState: DEFAULT_STATE,
+        twoFactorAuthResendSuccess: false,
+      };
+    case TWO_FACTOR_AUTH_VERIFY.BEGIN:
+      return {
+        ...state,
+        twoFactorAuthSubmitState: PENDING_STATE,
+        twoFactorAuthErrorCode: '',
+      };
+    case TWO_FACTOR_AUTH_VERIFY.SUCCESS:
+      return {
+        ...state,
+        twoFactorAuthSubmitState: DEFAULT_STATE,
+        loginResult: { redirectUrl: action.payload.redirectUrl, success: true },
+      };
+    case TWO_FACTOR_AUTH_VERIFY.FAILURE:
+      return {
+        ...state,
+        twoFactorAuthSubmitState: DEFAULT_STATE,
+        twoFactorAuthErrorCode: action.payload.errorCode,
+      };
+    case TWO_FACTOR_AUTH_RESEND.BEGIN:
+      return {
+        ...state,
+        twoFactorAuthResendState: PENDING_STATE,
+        twoFactorAuthResendSuccess: false,
+        twoFactorAuthErrorCode: '',
+      };
+    case TWO_FACTOR_AUTH_RESEND.SUCCESS:
+      return {
+        ...state,
+        twoFactorAuthResendState: DEFAULT_STATE,
+        twoFactorAuthResendSuccess: true,
+      };
+    case TWO_FACTOR_AUTH_RESEND.FAILURE:
+      return {
+        ...state,
+        twoFactorAuthResendState: DEFAULT_STATE,
+        twoFactorAuthErrorCode: action.payload.errorCode,
+      };
     case RESET_PASSWORD.SUCCESS:
       return {
         ...state,

--- a/src/login/data/sagas.js
+++ b/src/login/data/sagas.js
@@ -1,28 +1,49 @@
 import { camelCaseObject } from '@edx/frontend-platform';
 import { logError, logInfo } from '@edx/frontend-platform/logging';
-import { call, put, takeEvery } from 'redux-saga/effects';
+import {
+  call, put, takeLatest, takeLeading,
+} from 'redux-saga/effects';
 
 import {
   LOGIN_REQUEST,
+  TWO_FACTOR_AUTH_VERIFY,
+  TWO_FACTOR_AUTH_RESEND,
   loginRequestBegin,
   loginRequestFailure,
   loginRequestSuccess,
+  twoFactorAuthRequired,
+  twoFactorAuthVerifyBegin,
+  twoFactorAuthVerifySuccess,
+  twoFactorAuthVerifyFailure,
+  twoFactorAuthResendBegin,
+  twoFactorAuthResendSuccess,
+  twoFactorAuthResendFailure,
 } from './actions';
-import { FORBIDDEN_REQUEST, INTERNAL_SERVER_ERROR } from './constants';
+import {
+  FORBIDDEN_REQUEST,
+  INTERNAL_SERVER_ERROR,
+  TWO_FACTOR_AUTH_REQUIRED as TWO_FACTOR_AUTH_REQUIRED_CODE,
+} from './constants';
 import {
   loginRequest,
+  verifyOtp,
+  resendOtp,
 } from './service';
 
 export function* handleLoginRequest(action) {
   try {
     yield put(loginRequestBegin());
 
-    const { redirectUrl, success } = yield call(loginRequest, action.payload.creds);
+    const {
+      redirectUrl, success, errorCode, maskedEmail,
+    } = yield call(loginRequest, action.payload.creds);
 
-    yield put(loginRequestSuccess(
-      redirectUrl,
-      success,
-    ));
+    if (!success && errorCode === TWO_FACTOR_AUTH_REQUIRED_CODE) {
+      yield put(twoFactorAuthRequired(maskedEmail));
+      return;
+    }
+
+    yield put(loginRequestSuccess(redirectUrl, success));
   } catch (e) {
     const statusCodes = [400];
     if (e.response) {
@@ -41,6 +62,52 @@ export function* handleLoginRequest(action) {
   }
 }
 
+export function* handleTwoFactorAuthVerify(action) {
+  try {
+    yield put(twoFactorAuthVerifyBegin());
+    const { redirectUrl, success } = yield call(verifyOtp, action.payload.otp);
+    if (success) {
+      yield put(twoFactorAuthVerifySuccess(redirectUrl));
+    } else {
+      yield put(twoFactorAuthVerifyFailure('2fa-invalid-otp'));
+    }
+  } catch (e) {
+    if (e.response) {
+      const { status } = e.response;
+      if (status === 400) {
+        yield put(twoFactorAuthVerifyFailure('2fa-invalid-otp'));
+      } else if (status === 401) {
+        yield put(twoFactorAuthVerifyFailure('2fa-session-expired'));
+      } else if (status === 429) {
+        yield put(twoFactorAuthVerifyFailure(FORBIDDEN_REQUEST));
+      } else {
+        yield put(twoFactorAuthVerifyFailure(INTERNAL_SERVER_ERROR));
+      }
+      logInfo(e);
+    } else {
+      yield put(twoFactorAuthVerifyFailure(INTERNAL_SERVER_ERROR));
+      logError(e);
+    }
+  }
+}
+
+export function* handleTwoFactorAuthResend() {
+  try {
+    yield put(twoFactorAuthResendBegin());
+    yield call(resendOtp);
+    yield put(twoFactorAuthResendSuccess());
+  } catch (e) {
+    if (e.response && e.response.status === 429) {
+      yield put(twoFactorAuthResendFailure('2fa-resend-rate-limited'));
+    } else {
+      yield put(twoFactorAuthResendFailure(INTERNAL_SERVER_ERROR));
+      logError(e);
+    }
+  }
+}
+
 export default function* saga() {
-  yield takeEvery(LOGIN_REQUEST.BASE, handleLoginRequest);
+  yield takeLeading(LOGIN_REQUEST.BASE, handleLoginRequest);
+  yield takeLeading(TWO_FACTOR_AUTH_VERIFY.BASE, handleTwoFactorAuthVerify);
+  yield takeLeading(TWO_FACTOR_AUTH_RESEND.BASE, handleTwoFactorAuthResend);
 }

--- a/src/login/data/service.js
+++ b/src/login/data/service.js
@@ -2,7 +2,6 @@ import { getConfig } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import * as QueryString from 'query-string';
 
-// eslint-disable-next-line import/prefer-default-export
 export async function loginRequest(creds) {
   const requestConfig = {
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
@@ -22,5 +21,36 @@ export async function loginRequest(creds) {
   return {
     redirectUrl: data.redirect_url || `${getConfig().LMS_BASE_URL}/dashboard`,
     success: data.success || false,
+    errorCode: data.error_code || null,
+    maskedEmail: data.masked_email || null,
   };
+}
+
+export async function verifyOtp(otp) {
+  const { data } = await getAuthenticatedHttpClient()
+    .post(
+      `${getConfig().LMS_BASE_URL}/api/2fa/v1/verify-login/`,
+      QueryString.stringify({ otp }),
+      { headers: { 'Content-Type': 'application/x-www-form-urlencoded' }, isPublic: true },
+    )
+    .catch((e) => {
+      throw (e);
+    });
+
+  return {
+    redirectUrl: data.redirect_url || `${getConfig().LMS_BASE_URL}/dashboard`,
+    success: data.success || false,
+  };
+}
+
+export async function resendOtp() {
+  await getAuthenticatedHttpClient()
+    .post(
+      `${getConfig().LMS_BASE_URL}/api/2fa/v1/resend/`,
+      {},
+      { isPublic: true },
+    )
+    .catch((e) => {
+      throw (e);
+    });
 }

--- a/src/login/messages.jsx
+++ b/src/login/messages.jsx
@@ -206,6 +206,87 @@ const messages = defineMessages({
         + '{lineBreak}{lineBreak}Error Details:{lineBreak}{errorMessage}',
     description: 'Error message third party authentication pipeline fails',
   },
+  // Two Factor Auth
+  '2fa.page.title': {
+    id: '2fa.page.title',
+    defaultMessage: 'Verify your identity',
+    description: '2FA page heading',
+  },
+  '2fa.description': {
+    id: '2fa.description',
+    defaultMessage: 'We sent a 6-digit verification code to your email. Enter it below to continue.',
+    description: '2FA description when masked email is unavailable',
+  },
+  '2fa.description.with.email': {
+    id: '2fa.description.with.email',
+    defaultMessage: 'We sent a 6-digit verification code to {maskedEmail}. Enter it below to continue.',
+    description: '2FA description showing the masked email address',
+  },
+  '2fa.otp.label': {
+    id: '2fa.otp.label',
+    defaultMessage: 'Verification code',
+    description: 'Label for the OTP input field',
+  },
+  '2fa.otp.validation.empty': {
+    id: '2fa.otp.validation.empty',
+    defaultMessage: 'Enter the verification code',
+    description: 'Validation message when OTP field is empty',
+  },
+  '2fa.otp.validation.format': {
+    id: '2fa.otp.validation.format',
+    defaultMessage: 'Verification code must be 6 digits',
+    description: 'Validation message when OTP format is invalid',
+  },
+  '2fa.verify.button': {
+    id: '2fa.verify.button',
+    defaultMessage: 'Verify',
+    description: 'Submit button label for OTP verification form',
+  },
+  '2fa.resend.button': {
+    id: '2fa.resend.button',
+    defaultMessage: "Didn't receive a code? Resend",
+    description: 'Button to resend the OTP',
+  },
+  '2fa.resend.button.pending': {
+    id: '2fa.resend.button.pending',
+    defaultMessage: 'Sending...',
+    description: 'Resend button label while request is in flight',
+  },
+  '2fa.resend.success': {
+    id: '2fa.resend.success',
+    defaultMessage: 'A new verification code has been sent to your email.',
+    description: 'Success message after OTP is resent',
+  },
+  '2fa.error.heading': {
+    id: '2fa.error.heading',
+    defaultMessage: 'Verification failed',
+    description: 'Heading for 2FA error alert',
+  },
+  '2fa.error.invalid.otp': {
+    id: '2fa.error.invalid.otp',
+    defaultMessage: 'The verification code you entered is incorrect or has expired. Please try again.',
+    description: 'Error when OTP is wrong or expired',
+  },
+  '2fa.error.session.expired': {
+    id: '2fa.error.session.expired',
+    defaultMessage: 'Your session has expired. Please sign in again.',
+    description: 'Error when the 2FA session has expired',
+  },
+  '2fa.error.resend.rate.limited': {
+    id: '2fa.error.resend.rate.limited',
+    defaultMessage: 'Too many resend requests. Please wait a few minutes before trying again.',
+    description: 'Error when resend OTP is rate limited',
+  },
+  '2fa.error.too.many.attempts': {
+    id: '2fa.error.too.many.attempts',
+    defaultMessage: 'Too many verification attempts. Please wait a few minutes before trying again.',
+    description: 'Error when OTP verification is rate limited',
+  },
+  '2fa.error.internal': {
+    id: '2fa.error.internal',
+    defaultMessage: 'An error occurred. Please try again.',
+    description: 'Generic 2FA error message',
+  },
 });
 
 export default messages;


### PR DESCRIPTION
#### Implemented Authentication Functionality for @frontend-app-authn 🚀


##### Changes Made 📈

- Implemented authentication functionality for @frontend-app-authn 📊
- Updated login views to handle authentication 📄
- Added error handling and logging to ensure that any issues with authentication are properly tracked and debugged 🚨



<img width="2484" height="1120" alt="image" src="https://github.com/user-attachments/assets/4837ecbc-3901-450f-baa7-4e52c58663e8" />


⚠️Stuff to confirm before deployment ⚠️ 

Getting an issue related to multiple calls being sent from the frontend (approx 10/15 at a time)


**The root cause:** `sagaMiddleware` was a module-level singleton.

`configureStore()` was called inside the component render, so every re-render (StrictMode double-render + each HMR reload from file saves) called `sagaMiddleware.run(rootSaga)` again on the same instance — stacking up duplicate saga watchers.

After N file saves during development, N copies of `handleLoginRequest` were all watching `LOGIN_REQUEST.BASE`, so one dispatch fired N HTTP requests simultaneously.

