### PR TITLE
fix(auth): Third-party auth provider icons not loading in MFE

### DIFF
--- a/src/common-components/EnterpriseSSO.jsx
+++ b/src/common-components/EnterpriseSSO.jsx
@@ -12,6 +12,7 @@ import PropTypes from 'prop-types';
 
 import messages from './messages';
 import { LOGIN_PAGE, SUPPORTED_ICON_CLASSES } from '../data/constants';
+import { getTpaProviderIconUrl } from '../data/utils';
 
 /**
  * This component renders the Single sign-on (SSO) button only for the tpa provider passed
@@ -49,7 +50,7 @@ const EnterpriseSSO = (props) => {
               >
                 {tpaProvider.iconImage ? (
                   <div aria-hidden="true">
-                    <img className="btn-tpa__image-icon" src={tpaProvider.iconImage} alt={`icon ${tpaProvider.name}`} />
+                    <img className="btn-tpa__image-icon" src={getTpaProviderIconUrl(tpaProvider.iconImage)} alt={`icon ${tpaProvider.name}`} />
                     <span className="pl-2" aria-hidden="true">{ tpaProvider.name }</span>
                   </div>
                 )

--- a/src/common-components/SocialAuthProviders.jsx
+++ b/src/common-components/SocialAuthProviders.jsx
@@ -9,6 +9,7 @@ import PropTypes from 'prop-types';
 
 import messages from './messages';
 import { LOGIN_PAGE, SUPPORTED_ICON_CLASSES } from '../data/constants';
+import { getTpaProviderIconUrl } from '../data/utils';
 
 const SocialAuthProviders = (props) => {
   const { formatMessage } = useIntl();
@@ -32,7 +33,7 @@ const SocialAuthProviders = (props) => {
     >
       {provider.iconImage ? (
         <div aria-hidden="true">
-          <img className="btn-tpa__image-icon" src={provider.iconImage} alt={`icon ${provider.name}`} />
+          <img className="btn-tpa__image-icon" src={getTpaProviderIconUrl(provider.iconImage)} alt={`icon ${provider.name}`} />
         </div>
       )
         : (

--- a/src/data/utils/dataUtils.js
+++ b/src/data/utils/dataUtils.js
@@ -1,4 +1,5 @@
 // Utility functions
+import { getConfig } from '@edx/frontend-platform';
 import * as QueryString from 'query-string';
 
 import { AUTH_PARAMS } from '../constants';
@@ -80,4 +81,11 @@ export const windowScrollTo = (options) => {
 export const isHostAvailableInQueryParams = () => {
   const queryParams = getAllPossibleQueryParams();
   return 'host' in queryParams;
+};
+
+export const getTpaProviderIconUrl = (iconImage) => {
+  if (!iconImage) {
+    return iconImage;
+  }
+  return /^https?:\/\//i.test(iconImage) ? iconImage : `${getConfig().LMS_BASE_URL}${iconImage}`;
 };

--- a/src/data/utils/index.js
+++ b/src/data/utils/index.js
@@ -3,6 +3,7 @@ export {
   getTpaHint,
   getAllPossibleQueryParams,
   getActivationStatus,
+  getTpaProviderIconUrl,
   isHostAvailableInQueryParams,
   updatePathWithQueryParams,
   windowScrollTo,


### PR DESCRIPTION
Provider icon images (e.g. Paypeople logo) render as broken images on the login/register pages because the API returns a relative /media/... path, but the authn MFE runs on a different subdomain (apps.<LMS_HOST>) than the LMS (<LMS_HOST>) that actually serves /media. Added getTpaProviderIconUrl() to prefix relative icon paths with LMS_BASE_URL, mirroring the existing handling for provider login/register URLs.

TIcket: https://github.com/edly-io/tutor-contrib-fbr/issues/231

<img width="1919" height="922" alt="Screenshot 2026-07-09 at 11 34 22 PM" src="https://github.com/user-attachments/assets/b7ed7577-43d5-4056-83f3-95f2aed623bb" />
