### PR TITLE
fix(logistration): skip EmailCheckWidget during active SSO pipeline [EDLYPRODUCT-8357]

### DIFF
--- a/src/logistration/Logistration.jsx
+++ b/src/logistration/Logistration.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector, connect } from 'react-redux';
 
 // Todo: need to change imports when package is published to edly-io
-import { emailCheckComplete, EmailCheckWidget } from '@anas_hameed/edly-saas-widget';
+import { emailCheckComplete, EmailCheckWidget } from '@anas_hameed/edly-saas-widget/src';
 import { getConfig } from '@edx/frontend-platform';
 import { sendPageEvent, sendTrackEvent } from '@edx/frontend-platform/analytics';
 import { getAuthService } from '@edx/frontend-platform/auth';
@@ -18,8 +18,9 @@ import { Navigate, useNavigate } from 'react-router-dom';
 
 import BaseContainer from '../base-container';
 import { FormGroup } from '../common-components';
-import { clearThirdPartyAuthContextErrorMessage } from '../common-components/data/actions';
+import { clearThirdPartyAuthContextErrorMessage, getThirdPartyAuthContext } from '../common-components/data/actions';
 import {
+  thirdPartyAuthContextSelector,
   tpaProvidersSelector,
 } from '../common-components/data/selectors';
 import messages from '../common-components/messages';
@@ -40,6 +41,7 @@ const Logistration = (props) => {
   const { selectedPage: selectedPageProp, showEmailCheck } = props;
   const tpaHint = getTpaHint();
   const tpaProviders = useSelector(tpaProvidersSelector);
+  const { currentProvider } = useSelector(thirdPartyAuthContextSelector);
   const dispatch = useDispatch();
   const {
     providers,
@@ -120,7 +122,7 @@ const Logistration = (props) => {
   };
 
   const activationMsgType = getActivationStatus();
-  if (showEmailCheck && !tpaHint) {
+  if (showEmailCheck && !tpaHint && !currentProvider) {
     return (
       <EmailCheckWidget
         onEmailCheckComplete={handleEmailCheckComplete}
@@ -130,6 +132,7 @@ const Logistration = (props) => {
         VALID_EMAIL_REGEX={VALID_EMAIL_REGEX}
         AccountActivationMessage={AccountActivationMessage}
         ResetPasswordSuccess={ResetPasswordSuccess}
+        fetchTpaContext={getThirdPartyAuthContext}
       />
     );
   }

--- a/src/logistration/Logistration.jsx
+++ b/src/logistration/Logistration.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector, connect } from 'react-redux';
 
 // Todo: need to change imports when package is published to edly-io
-import { emailCheckComplete, EmailCheckWidget } from '@anas_hameed/edly-saas-widget/src';
+import { emailCheckComplete, EmailCheckWidget } from '@anas_hameed/edly-saas-widget';
 import { getConfig } from '@edx/frontend-platform';
 import { sendPageEvent, sendTrackEvent } from '@edx/frontend-platform/analytics';
 import { getAuthService } from '@edx/frontend-platform/auth';


### PR DESCRIPTION
## Problem
On a post-SSO return, users landed on `/authn/login` and saw the custom `EmailCheckWidget` instead of the normal SSO-completion flow. The widget renders whenever `showEmailCheck && !tpaHint`, and a post-SSO redirect carries no `tpa_hint`, so it intercepted the flow and blocked the authn MFE's auto-submit/registration-completion logic (which keys off `thirdPartyAuthContext.currentProvider`).

## Fix
Gate the widget on `!currentProvider`. When a third-party-auth pipeline is active, fall through to `RegistrationPage`/`LoginPage` so the SSO completion runs. The TPA-context fetch + loading spinner now live inside `EmailCheckWidget` (companion PR); this side just passes the fetch action and reads `currentProvider`.

## Testing
- Google SSO register → widget no longer intercepts → SSO completion → dashboard.
- Plain email signup (no SSO) → `EmailCheckWidget` shows as before.

## Notes
- Companion PR: edly-io/frontend-saas-widgets#10 (must be published/built for this side to consume it; this branch uses the `/src` dev import).
- EDLYPRODUCT-8357